### PR TITLE
server_nginx recipe template @chef_env missing 

### DIFF
--- a/recipes/server_nginx.rb
+++ b/recipes/server_nginx.rb
@@ -32,7 +32,8 @@ template munin_conf do
     :docroot => node['munin']['docroot'],
     :log_dir => node['nginx']['log_dir'],
     :listen_port => node['munin']['web_server_port'],
-    :htpasswd_file => File.join(node['munin']['basedir'], 'htpasswd.users')
+    :htpasswd_file => File.join(node['munin']['basedir'], 'htpasswd.users'),
+    :chef_env => node.chef_environment == '_default' ? 'default' : node.chef_environment
   )
   if(::File.symlink?(munin_conf))
     notifies :reload, 'service[nginx]'

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -1,5 +1,5 @@
 server {
-
+  
   listen <%= @listen_port %>;
   server_name munin munin.<%= @chef_env %>.<%= @public_domain %> <%= @fqdn %>;
   access_log <%= File.join(@log_dir, 'nginx_access.log') %>;
@@ -8,7 +8,7 @@ server {
   location /munin {
     root <%= @docroot %>;
   }
-
+  
   location / {
     auth_basic "Munin Server";
     auth_basic_user_file <%= @htpasswd_file %>;

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -1,7 +1,7 @@
 server {
 
   listen <%= @listen_port %>;
-  server_name munin munin.<%= @chef_environment %>.<%= @public_domain %> <%= @fqdn %>;
+  server_name munin munin.<%= @chef_env %>.<%= @public_domain %> <%= @fqdn %>;
   access_log <%= File.join(@log_dir, 'nginx_access.log') %>;
   error_log <%= File.join(@log_dir, 'nginx_error.log') %>;
 

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -1,14 +1,14 @@
 server {
-  
+
   listen <%= @listen_port %>;
-  server_name munin munin.<%= @chef_env %>.<%= @public_domain %> <%= @fqdn %>;
+  server_name munin munin.<%= @chef_environment %>.<%= @public_domain %> <%= @fqdn %>;
   access_log <%= File.join(@log_dir, 'nginx_access.log') %>;
   error_log <%= File.join(@log_dir, 'nginx_error.log') %>;
 
   location /munin {
     root <%= @docroot %>;
   }
-  
+
   location / {
     auth_basic "Munin Server";
     auth_basic_user_file <%= @htpasswd_file %>;


### PR DESCRIPTION
@chev_env is not defined within the template block, causing the server_nginx recipe to fail. Template outputs munin..example.com instead of munin.production.example.com

http://tickets.opscode.com/browse/COOK-2140
