### PR TITLE
Create the munin client log directory

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,7 +19,7 @@
 
 if node['munin']['multi_environment_monitoring']
   munin_servers = search(:node, "role:#{node['munin']['server_role']}")
-else  
+else
   munin_servers = search(:node, "role:#{node['munin']['server_role']} AND chef_environment:#{node.chef_environment}")
 end
 
@@ -30,6 +30,11 @@ service_name = node['munin']['service_name']
 service service_name do
   supports :restart => true
   action :enable
+end
+
+directory '/var/log/munin' do
+  mode '755'
+  action :create
 end
 
 template "#{node['munin']['basedir']}/munin-node.conf" do


### PR DESCRIPTION
Addresses issue in http://tickets.opscode.com/browse/COOK-2881, which prevents the munin client from launching because the log directory doesn't exist
