### PR TITLE
COOK-3224 Fix template crashing due to non-existent sort operator

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -23,6 +23,8 @@ else
   munin_servers = search(:node, "role:#{node['munin']['server_role']} AND chef_environment:#{node.chef_environment}")
 end
 
+munin_servers.sort! { |a,b| a[:name] <=> b[:name] }
+
 package "munin-node"
 
 service_name = node['munin']['service_name']

--- a/templates/default/munin-node.conf.erb
+++ b/templates/default/munin-node.conf.erb
@@ -36,7 +36,7 @@ host_name <%= node[:hostname] %>.ec2.internal
 # doesn't understand CIDR-style network notation.  You may repeat
 # the allow line as many times as you'd like
 
-<% @munin_servers.sort.each do |server| -%>
+<% @munin_servers.sort{ |a,b| a.name <=> b.name }.each do |server| -%>
 allow ^<%= server[:ipaddress].to_s.gsub(/\./, '\.') %>$
 <% end -%>
 allow ^127\.0\.0\.1$

--- a/templates/default/munin-node.conf.erb
+++ b/templates/default/munin-node.conf.erb
@@ -36,7 +36,7 @@ host_name <%= node[:hostname] %>.ec2.internal
 # doesn't understand CIDR-style network notation.  You may repeat
 # the allow line as many times as you'd like
 
-<% @munin_servers.sort{ |a,b| a.name <=> b.name }.each do |server| -%>
+<% @munin_servers.each do |server| -%>
 allow ^<%= server[:ipaddress].to_s.gsub(/\./, '\.') %>$
 <% end -%>
 allow ^127\.0\.0\.1$


### PR DESCRIPTION
Chef::Node on 11.4.4 doesn't have the sort operator, causing the
template to crash with "comparison of Chef::Node with Chef::Node failed"
