### PR TITLE
[COOK-3581] Ensure munin-node is started before enabling

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -31,7 +31,7 @@ service_name = node['munin']['service_name']
 
 service service_name do
   supports :restart => true
-  action :enable
+  action [:start,:enable]
 end
 
 template "#{node['munin']['basedir']}/munin-node.conf" do


### PR DESCRIPTION
The munin::client recipe should ensure that munin-node starts successfully before enabling the service on boot. Without this, the service will only get started if the configuration file is updated.

https://tickets.opscode.com/browse/COOK-3581
