### PR TITLE
Allow new-er versions apache and nginx cookbooks to be used with munin

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,8 @@ description       'Installs and configures munin'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '1.4.1'
 
-depends 'apache2', '~> 1.7'
-depends 'nginx',   '~> 1.8'
+depends 'apache2', '>= 1.7'
+depends 'nginx',   '>= 1.8'
 
 supports 'arch'
 supports 'centos'


### PR DESCRIPTION
Latest nginx cookbook version is 2.0.x making it impossible to use `librarian-chef` with both latest nginx and latest munin (although they work fine together).
