### PR TITLE
Include /etc/munin/munin-conf.d for additional configuration

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -113,6 +113,10 @@ template "#{node['munin']['basedir']}/munin.conf" do
   )
 end
 
+directory "#{node['munin']['basedir']}/munin-conf.d" do
+  action :create
+end
+
 case node['munin']['server_auth_method']
 when 'openid'
   if web_srv == :apache

--- a/templates/default/munin.conf.erb
+++ b/templates/default/munin.conf.erb
@@ -22,6 +22,8 @@ max_processes <%= node['munin']['max_processes'] %>
 max_graph_jobs <%= node['munin']['max_graph_jobs'] %>
 max_cgi_graph_jobs <%= node['munin']['max_cgi_graph_jobs'] %>
 
+includedir <%= node['munin']['basedir'] %>/munin-conf.d
+
 # a simple host tree
 <% @munin_nodes.each do |system| -%>
 [<%= system['fqdn'] %>]


### PR DESCRIPTION
When munin.conf is created by chef, its nice to have the munin-conf.d included so one can add custom nodes with manual config. Like for snmp-nodes or legacy-machines that aren't findable on chef.

This PR depends on current master, not on one of the other PRs from me:)

Ticket COOK-4133 in tickets.opscode.com
