### PR TITLE
Allow cgi strategy for html and graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Attributes
 - `node['munin']['docroot']` - document root for the server apache vhost. on archlinux, the default is `/srv/http/munin`, or `/var/www/munin` on other platforms.
 - `node['munin']['web_server']` - supports apache or nginx, default is "apache"
 - `node['munin']['public_domain']` - override munin domain.
+- `node['munin']['graph_strategy']` - choose a graphing strategy. Default is unset, meaning munins default. `cgi` does graph-generation on demand by cgi.
 - `node['munin']['max_processes']` - Maximum number of simultaneous Munin-update processes. When not set, munin will use as many as necessary. Default is to use as many as necessary.
 - `node['munin']['max_graph_jobs']` - Maximum number of parallel processes used by munin-graph when calling rrdgraph, default is "6"
 - `node['munin']['max_cgi_graph_jobs']` - Maximum number of parallel munin-cgi-graph or munin-fastcgi-graph jobs, default is "6"

--- a/recipes/server_apache.rb
+++ b/recipes/server_apache.rb
@@ -24,6 +24,10 @@ end
 include_recipe 'apache2::default'
 include_recipe 'apache2::mod_rewrite'
 
+if node['munin'].fetch('graph_strategy', 'cron') == 'cgi'
+  include_recipe 'apache2::mod_fcgid'
+end
+
 apache_site '000-default' do
   enable false
 end

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -30,4 +30,42 @@
   RewriteEngine On
   RewriteCond %{THE_REQUEST} ^[A-Z]{3,9}\ /.*index\.html\ HTTP/
   RewriteRule ^(.*)index\.html$ $1 [R=301,L]
+
+<% if node['munin'].fetch('graph_strategy', 'cron') == 'cgi' %>
+  <IfModule mod_rewrite.c>
+    # Rewrite rules to serve traffic from the root instead of /munin-cgi
+    RewriteEngine On
+
+    # Static files
+    RewriteRule ^/favicon.ico /var/www/munin/static/favicon.ico [L]
+    RewriteRule ^/static/(.*) /var/www/munin/static/$1          [L]
+
+    # HTML
+    RewriteRule ^(/.*\.html)?$           /munin-cgi/munin-cgi-html/$1 [PT]
+
+    # Images
+    RewriteRule ^/munin-cgi/munin-cgi-graph/(.*) /$1
+    RewriteCond %{REQUEST_URI}                 !^/static
+    RewriteRule ^/(.*.png)$  /munin-cgi/munin-cgi-graph/$1 [L,PT]
+  </IfModule>
+
+  # Ensure we can run (fast)cgi scripts
+  ScriptAlias /munin-cgi/munin-cgi-graph /usr/lib/munin/cgi/munin-cgi-graph
+  <Location /munin-cgi/munin-cgi-graph>
+    Options +ExecCGI
+    <IfModule mod_fcgid.c>
+      SetHandler fcgid-script
+    </IfModule>
+    Allow from all
+  </Location>
+
+  ScriptAlias /munin-cgi/munin-cgi-html /usr/lib/munin/cgi/munin-cgi-html
+  <Location /munin-cgi/munin-cgi-html>
+    Options +ExecCGI
+    <IfModule mod_fcgid.c>
+      SetHandler fcgid-script
+    </IfModule>
+    Allow from all
+  </Location>
+<% end %>
 </VirtualHost>

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -27,45 +27,32 @@
   </Location>
 <% end -%>
 
-  RewriteEngine On
-  RewriteCond %{THE_REQUEST} ^[A-Z]{3,9}\ /.*index\.html\ HTTP/
-  RewriteRule ^(.*)index\.html$ $1 [R=301,L]
-
 <% if node['munin'].fetch('graph_strategy', 'cron') == 'cgi' %>
-  <IfModule mod_rewrite.c>
-    # Rewrite rules to serve traffic from the root instead of /munin-cgi
-    RewriteEngine On
+  # Rewrites
+  RewriteEngine On
 
-    # Static files
-    RewriteRule ^/favicon.ico /var/www/munin/static/favicon.ico [L]
-    RewriteRule ^/static/(.*) /var/www/munin/static/$1          [L]
+  # Static content in static
+  RewriteRule ^/favicon.ico /etc/munin/static/favicon.ico [L]
+  RewriteRule ^/static/(.*) /etc/munin/static/$1          [L]
 
-    # HTML
-    RewriteRule ^(/.*\.html)?$           /munin-cgi/munin-cgi-html/$1 [PT]
+  # HTML
+  RewriteCond %{REQUEST_URI} .html$ [or]
+  RewriteCond %{REQUEST_URI} !.png$
+  RewriteRule ^/(.*) /usr/lib/munin/cgi/munin-cgi-html/$1 [L]
 
-    # Images
-    RewriteRule ^/munin-cgi/munin-cgi-graph/(.*) /$1
-    RewriteCond %{REQUEST_URI}                 !^/static
-    RewriteRule ^/(.*.png)$  /munin-cgi/munin-cgi-graph/$1 [L,PT]
-  </IfModule>
+  # Images
+  RewriteRule ^/munin-cgi/munin-cgi-graph/(.*) /$1
+  RewriteRule ^/(.*\.png) /usr/lib/munin/cgi/munin-cgi-graph/$1 [L]
 
   # Ensure we can run (fast)cgi scripts
-  ScriptAlias /munin-cgi/munin-cgi-graph /usr/lib/munin/cgi/munin-cgi-graph
-  <Location /munin-cgi/munin-cgi-graph>
+  <Directory "/usr/lib/munin/cgi">
     Options +ExecCGI
     <IfModule mod_fcgid.c>
       SetHandler fcgid-script
     </IfModule>
-    Allow from all
-  </Location>
-
-  ScriptAlias /munin-cgi/munin-cgi-html /usr/lib/munin/cgi/munin-cgi-html
-  <Location /munin-cgi/munin-cgi-html>
-    Options +ExecCGI
-    <IfModule mod_fcgid.c>
-      SetHandler fcgid-script
+    <IfModule !mod_fcgid.c>
+      SetHandler cgi-script
     </IfModule>
-    Allow from all
-  </Location>
+  </Directory>
 <% end %>
 </VirtualHost>

--- a/templates/default/munin.conf.erb
+++ b/templates/default/munin.conf.erb
@@ -24,8 +24,10 @@ max_cgi_graph_jobs <%= node['munin']['max_cgi_graph_jobs'] %>
 
 includedir <%= node['munin']['basedir'] %>/munin-conf.d
 
-<% if node['munin']['graph_strategy'] %>
+<% if node['munin'].fetch('graph_strategy', 'cron') == 'cgi' %>
 graph_strategy <%= node['munin']['graph_strategy'] %>
+html_strategy <%= node['munin']['graph_strategy'] %>
+cgiurl_graph /munin-cgi/munin-cgi-graph
 <% end %>
 
 # a simple host tree

--- a/templates/default/munin.conf.erb
+++ b/templates/default/munin.conf.erb
@@ -24,6 +24,10 @@ max_cgi_graph_jobs <%= node['munin']['max_cgi_graph_jobs'] %>
 
 includedir <%= node['munin']['basedir'] %>/munin-conf.d
 
+<% if node['munin']['graph_strategy'] %>
+graph_strategy <%= node['munin']['graph_strategy'] %>
+<% end %>
+
 # a simple host tree
 <% @munin_nodes.each do |system| -%>
 [<%= system['fqdn'] %>]

--- a/templates/default/munin.conf.erb
+++ b/templates/default/munin.conf.erb
@@ -27,7 +27,6 @@ includedir <%= node['munin']['basedir'] %>/munin-conf.d
 <% if node['munin'].fetch('graph_strategy', 'cron') == 'cgi' %>
 graph_strategy <%= node['munin']['graph_strategy'] %>
 html_strategy <%= node['munin']['graph_strategy'] %>
-cgiurl_graph /munin-cgi/munin-cgi-graph
 <% end %>
 
 # a simple host tree


### PR DESCRIPTION
Activate cgi-generation of graphs (and html).

Instead of generating html and pngs all day and night long, it might be easier if that is just generated when someone is looking at it. (To solve the question: if a graph is generated but no one is there to look at it, is the graph really generated?)

So far I only used that together with apache.
