### PR TITLE
Allow access from all munin-server to the clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Attributes
 Recipes
 -------
 ### client
-The client recipe installs munin-node package and starts the service. It also searches for a node with the role for the munin server, by default `node['munin']['server_role']`. On Archlinux, it builds the list of plugins to enable.
+The client recipe installs munin-node package and starts the service. It also searches for nodes with the role for the munin server, by default `node['munin']['server_role']` to allow access from their ip-addresses. On Archlinux, it builds the list of plugins to enable.
 
 ### server
 The server recipe will set up the munin server with Apache. It will create a cron job for generating the munin graphs, search for any nodes that have munin attributes (`node['munin']`), and use those nodes to connect for the graphs.

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -22,11 +22,7 @@ service_name = node['munin']['service_name']
 if Chef::Config[:solo]
   munin_servers = [node]
 else
-  if node['munin']['multi_environment_monitoring']
-    munin_servers = search(:node, "role:#{node['munin']['server_role']}")
-  else
-    munin_servers = search(:node, "role:#{node['munin']['server_role']} AND chef_environment:#{node.chef_environment}")
-  end
+  munin_servers = search(:node, "role:#{node['munin']['server_role']}")
 end
 
 munin_servers.sort! { |a, b| a['name'] <=> b['name'] }

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,12 +20,15 @@
 service_name = node['munin']['service_name']
 
 if Chef::Config[:solo]
-  munin_servers = [node]
+  munin_servers = [node['ipaddress']]
 else
-  munin_servers = search(:node, "role:#{node['munin']['server_role']}")
+  munin_servers = []
+  search(:node, "role:#{node['munin']['server_role']}").each do |srv|
+    munin_servers << srv['ipaddress']
+  end
 end
 
-munin_servers.sort! { |a, b| a['name'] <=> b['name'] }
+munin_servers.sort!
 
 package 'munin-node'
 

--- a/templates/default/munin-node.conf.erb
+++ b/templates/default/munin-node.conf.erb
@@ -33,8 +33,8 @@ host_name <%= node['hostname'] %>.ec2.internal
 # regular expression, due to brain damage in Net::Server, which
 # doesn't understand CIDR-style network notation.  You may repeat
 # the allow line as many times as you'd like
-<% @munin_servers.each do |server| -%>
-allow ^<%= server['ipaddress'].to_s.gsub(/\./, '\.') %>$
+<% @munin_servers.each do |ip| -%>
+allow ^<%= ip.to_s.gsub(/\./, '\.') %>$
 <% end -%>
 allow ^127\.0\.0\.1$
 


### PR DESCRIPTION
With the extended multi-environment-monitoring, nodes can be monitored from several servers:
- non-'multi_environment_monitoring'-servers in the same environment
- 'multi_environment_monitoring'-servers in different environments

Allow them all to access the node.
