### PR TITLE
Added node['munin']['server_list']

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'berkshelf',  '~> 2.0'
 gem 'chefspec',   '~> 3.1'
+gem 'rspec',      '~> 2.14'
 gem 'foodcritic', '~> 3.0'
 gem 'rubocop',    '~> 0.12'
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Attributes
 - `node['munin']['server_auth_method']` - the authentication method to use, default is openid. Any other value will use htauth basic with an htpasswd file.
 - `node['munin']['multi_environment_monitoring']` - allow multi-environment monitoring.  Default is false. Allowed values are 'true', 'false' or a list of names of chef-environments.
 - `node['munin']['server_role']` - role of the munin server. Default is monitoring.
+- `node['munin']['server_list']` - list of servers. This overrides `server_role`. Default is `nil`.
 - `node['munin']['docroot']` - document root for the server apache vhost. on archlinux, the default is `/srv/http/munin`, or `/var/www/munin` on other platforms.
 - `node['munin']['web_server']` - supports apache or nginx, default is "apache"
 - `node['munin']['public_domain']` - override munin domain.
@@ -47,6 +48,11 @@ Recipes
 -------
 ### client
 The client recipe installs munin-node package and starts the service. It also searches for a node with the role for the munin server, by default `node['munin']['server_role']`. On Archlinux, it builds the list of plugins to enable.
+
+If you want finer control over the munin servers to use, you can set
+`node['munin']['server_list']` to a list of server ip addresses or host names.
+For example, you can use a wrapper cookbook to set this based on a complicated
+search.
 
 ### server
 The server recipe will set up the munin server with Apache. It will create a cron job for generating the munin graphs, search for any nodes that have munin attributes (`node['munin']`), and use those nodes to connect for the graphs.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 
 default['munin']['sysadmin_email'] = 'ops@example.com'
 default['munin']['server_role'] = 'monitoring'
+default['munin']['server_list'] = nil
 default['munin']['server_auth_method'] = 'openid'
 default['munin']['multi_environment_monitoring'] = false
 

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -7,14 +7,87 @@ describe 'munin::client' do
     expect(chef_run).to install_package('munin-node')
   end
 
-  it 'writes the munin-node.conf' do
-    expect(chef_run).to create_template('/etc/munin/munin-node.conf').with(
-      source: 'munin-node.conf.erb',
-      mode: '0644'
-    )
+  describe 'the munin-node.conf' do
+    let(:conf_path) { '/etc/munin/munin-node.conf' }
 
-    template = chef_run.template('/etc/munin/munin-node.conf')
-    expect(template).to notify('service[munin-node]').to(:restart)
+    it 'is based on the template' do
+      expect(chef_run)
+        .to create_template(conf_path)
+        .with(source: 'munin-node.conf.erb')
+    end
+
+    it 'is mode 0644' do
+      expect(chef_run)
+        .to create_template(conf_path)
+        .with(mode: '0644')
+    end
+
+    describe 'template' do
+      it 'notifies munin-node to restart' do
+        template = chef_run.template(conf_path)
+        expect(template)
+          .to notify('service[munin-node]')
+          .to(:restart)
+      end
+
+      context 'with a list of server names' do
+        let(:chef_run) do
+          ChefSpec::Runner.new do |node|
+            node.normal['munin']['server_list'] = fake_dns.keys
+          end.converge(described_recipe)
+        end
+
+        before do
+          fake_dns.each_pair do |host, ip|
+            allow(IPSocket)
+              .to receive(:getaddress)
+              .with(host)
+              .and_return(ip)
+          end
+        end
+
+        let(:fake_dns) do
+          {
+            'server1.example.com' => '127.0.1.1',
+            'server2.example.com' => '127.0.1.2'
+          }
+        end
+
+        it 'always allows access to localhost' do
+          expect(chef_run)
+            .to render_file(conf_path)
+            .with_content('allow ^127\.0\.0\.1$')
+        end
+
+        it 'allows access to the servers' do
+          fake_dns.values.each do |ip|
+            expect(chef_run)
+              .to render_file(conf_path)
+              .with_content("allow ^#{ip.gsub('.', '\\.')}$")
+          end
+        end
+
+        it 'looks up the ip addresses' do
+          fake_dns.keys.each do |host|
+            expect(IPSocket)
+              .to receive(:getaddress)
+              .with(host)
+          end
+
+          chef_run
+        end
+      end
+
+      context 'with chef-solo' do
+        it 'allows itself access' do
+          expect(chef_run)
+            .to render_file(conf_path)
+            .with_content('allow ^127\.0\.0\.1$')
+        end
+      end
+
+      # TODO: Test the non-chef-solo path
+    end
   end
 
   it 'starts and enables the service' do

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -8,7 +8,7 @@ describe 'munin::server' do
   end
 
   before do
-    Chef::Recipe.any_instance.stub(:data_bag).with('users').and_return(%w[seth nathen])
+    Chef::Recipe.any_instance.stub(:data_bag).with('users').and_return(%w(seth nathen))
 
     Chef::Recipe.any_instance.stub(:data_bag_item).with('users', 'seth').and_return(
       Mash.new(id: 'seth', htpasswd: 'abc123')

--- a/templates/default/munin-node.conf.erb
+++ b/templates/default/munin-node.conf.erb
@@ -33,8 +33,6 @@ host_name <%= node['hostname'] %>.ec2.internal
 # regular expression, due to brain damage in Net::Server, which
 # doesn't understand CIDR-style network notation.  You may repeat
 # the allow line as many times as you'd like
-<% @munin_servers.each do |server| -%>
-allow ^<%= server['ipaddress'].to_s.gsub(/\./, '\.') %>$
+<% @munin_server_ips.each do |ipaddress| -%>
+allow ^<%= ipaddress.gsub(/\./, '\.') %>$
 <% end -%>
-allow ^127\.0\.0\.1$
-


### PR DESCRIPTION
This allows finer grain control of the server list.  Including allowing for
the server to be outside this chef-server's control.

Use cases:
- Use chef-solo/zero to deploy testing VMs but wanting to report to
  different server(s).
- When migrating from another system (e.g. puppet) to Chef and the
  server(s) haven't been moved yet.
