### PR TITLE
Support disabling server auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Attributes
 ----------
 - `node['munin']['web_server_port']` - port that the munin vhost runs on, default 80
 - `node['munin']['sysadmin_email']` - default email address for serveradmin in vhost.
-- `node['munin']['server_auth_method']` - the authentication method to use, default is openid. Any other value will use htauth basic with an htpasswd file.
+- `node['munin']['server_auth_method']` - the authentication method to use, default is openid. 'htauth' or 'htpasswd' will use htauth basic with an htpasswd file. Any other value will disable it.
 - `node['munin']['multi_environment_monitoring']` - allow multi-environment monitoring.  Default is false. Allowed values are 'true', 'false' or a list of names of chef-environments.
 - `node['munin']['server_role']` - role of the munin server. Default is monitoring.
 - `node['munin']['server_list']` - list of server ip addresses. This overrides `server_role`. Default is `nil`.
@@ -73,7 +73,7 @@ Create a `users` data bag that will contain the users that will be able to log i
 }
 ```
 
-When using `server_auth_method` 'openid', use the openid in the data bag item. Any other value for this attribute (e.g., "htauth", "htpasswd", etc) will use the htpasswd value as the password in `/etc/munin/htpasswd.users`.
+When using `server_auth_method` 'openid', use the openid in the data bag item. "htauth" or "htpasswd" will use the htpasswd value as the password in `/etc/munin/htpasswd.users`. Any other value for this attribute will disable any authentication method.
 
 - The openid must have the http:// and trailing /*. See __OpenID Authentication__ below for more information.
 

--- a/recipes/server_apache.rb
+++ b/recipes/server_apache.rb
@@ -36,4 +36,4 @@ template "#{node['apache']['dir']}/sites-available/munin.conf" do
   end
 end
 
-apache_site 'munin.conf'
+apache_site 'munin'

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -18,7 +18,7 @@
     require user <%= node['apache']['allowed_openids'].join(' ') %>
     AuthOpenIDDBLocation <%= node['apache']['mod_auth_openid']['dblocation'] %>
   </Location>
-<% else -%>
+<% when 'htauth', 'htpasswd' -%>
   <Location />
     AuthName "Munin Server"
     AuthType Basic


### PR DESCRIPTION
I prefer to use munin without authentication because it's deployed in internal network.
So I added options 'htauth' and 'htpassword' to `server_auth_method` to enable htpasswd.
And authentication method will be disabled if any other value was set.
