### PR TITLE
Remove apache2: stop statement

### DIFF
--- a/recipes/server_nginx.rb
+++ b/recipes/server_nginx.rb
@@ -17,10 +17,6 @@
 # limitations under the License.
 #
 
-service 'apache2' do
-  action :stop
-end
-
 include_recipe 'nginx::default'
 
 %w(default 000-default).each do |disable_site|


### PR DESCRIPTION
Because of this statement provisioning fails on a debian box. I also don't get why someone wants to stop apache when explicitly choosing nginx. 
