### PR TITLE
Create docroot directory recursively

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -146,7 +146,8 @@ else
 end
 
 directory node['munin']['docroot'] do
-  owner 'munin'
-  group 'munin'
-  mode  '0755'
+  owner     'munin'
+  group     'munin'
+  mode      '0755'
+  recursive true
 end


### PR DESCRIPTION
`/var/www` is not present on fresh Debian Wheezy installs.
