### PR TITLE
apache_site automatically appends .conf.

### DIFF
--- a/recipes/server_apache.rb
+++ b/recipes/server_apache.rb
@@ -36,4 +36,4 @@ template "#{node['apache']['dir']}/sites-available/munin.conf" do
   end
 end
 
-apache_site 'munin.conf'
+apache_site 'munin'


### PR DESCRIPTION
From the apache_site.rb from the apache cookbook: "conf_name = "#{params[:name]}.conf"

This change is needed because it is failing to activate the munin vhost:

I, [2015-05-28T15:17:19.987614 #16970]  INFO --:   \* execute[a2ensite munin.conf.conf] action run[2015-05-28T13:17:19+00:00] INFO: Processing execute[a2ensite munin.conf.conf] action run (munin::server_apache line 25)
