### PR TITLE
Add update_hostname_ec2 to not override ec2 hostname

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,7 @@ BlockNesting:
   Enabled: false # @todo enable this
 MethodLength:
   Max: 30
+
+# Disabled to allow spacing of variables for readability
+Style/SingleSpaceBeforeFirstArg:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Attributes
 - `node['munin']['sysadmin_email']` - default email address for serveradmin in vhost.
 - `node['munin']['server_auth_method']` - the authentication method to use, default is openid. Any other value will use htauth basic with an htpasswd file.
 - `node['munin']['multi_environment_monitoring']` - allow multi-environment monitoring.  Default is false. Allowed values are 'true', 'false' or a list of names of chef-environments.
+- `node['munin']['update_hostname_ec2']` - Updates the hostname to `#{node['hostname']}.ec2.internal` in munin-node.conf.  Otherwise the `hostname` directive is not specified. Default is true.
 - `node['munin']['server_role']` - role of the munin server. Default is monitoring.
 - `node['munin']['server_list']` - list of server ip addresses. This overrides `server_role`. Default is `nil`.
 - `node['munin']['docroot']` - document root for the server apache vhost. on archlinux, the default is `/srv/http/munin`, or `/var/www/munin` on other platforms.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,7 @@ default['munin']['server_role'] = 'monitoring'
 default['munin']['server_list'] = nil
 default['munin']['server_auth_method'] = 'openid'
 default['munin']['multi_environment_monitoring'] = false
+default['munin']['update_hostname_ec2'] = true
 
 default['munin']['web_server'] = 'apache'
 default['munin']['web_server_port'] = 80

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -22,8 +22,8 @@ service_name = node['munin']['service_name']
 
 if node['munin']['server_list']
   munin_server_ips = node['munin']['server_list']
-    .sort
-    .map { |hostname| IPSocket.getaddress(hostname) }
+                     .sort
+                     .map { |hostname| IPSocket.getaddress(hostname) }
 else
   if Chef::Config[:solo]
     munin_server_ips = [node['ipaddress']]
@@ -34,8 +34,8 @@ else
       munin_server_nodes = search(:node, "role:#{node['munin']['server_role']} AND chef_environment:#{node.chef_environment}")
     end
     munin_server_ips = munin_server_nodes
-      .sort { |a, b| a['name'] <=> b['name'] }
-      .map { |n| n['ipaddress'] }
+                       .sort { |a, b| a['name'] <=> b['name'] }
+                       .map { |n| n['ipaddress'] }
   end
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -62,7 +62,7 @@ if Chef::Config[:solo]
 else
   munin_servers = []
   if node['munin']['multi_environment_monitoring']
-    if node['munin']['multi_environment_monitoring'].kind_of?(Array)
+    if node['munin']['multi_environment_monitoring'].is_a?(Array)
       node['munin']['multi_environment_monitoring'].each do |searchenv|
         search(:node, "munin:[* TO *] AND chef_environment:#{searchenv}").each do |n|
           munin_servers << n

--- a/templates/default/munin-node.conf.erb
+++ b/templates/default/munin-node.conf.erb
@@ -25,7 +25,7 @@ ignore_file \.rpm(save|new)$
 # telnetting to localhost, port 4949
 #
 # host_name localhost.localdomain
-<% if node['ec2'] %>
+<% if node['ec2'] && node['munin']['update_hostname_ec2']%>
 host_name <%= node['hostname'] %>.ec2.internal
 <% end %>
 


### PR DESCRIPTION
By default all ec2 hosts were given a hostname directive in the munin-node.conf file with the value of <hostname>.ec2.internal.  This is should be optional.
